### PR TITLE
fix: decode to Buffer from base64

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ var binaryToBase64Replacer = function (key, value) {
 
 var base64ToBinaryReplacer = function (key, value) {
   return typeof value === "object" && value.base64 === true && typeof value.data === "string"
-    ? Buffer.from(value.data, "base64")
+    ? global.Buffer.from(value.data, "base64")
     : value;
 }
 

--- a/index.js
+++ b/index.js
@@ -54,6 +54,12 @@ var binaryToBase64Replacer = function (key, value) {
   return value;
 };
 
+var base64ToBinaryReplacer = function (key, value) {
+  return typeof value === "object" && value.base64 === true && typeof value.data === "string"
+    ? Buffer.from(value.data, "base64")
+    : value;
+}
+
 // Decode the data which was transmitted over the wire to a JavaScript Object in a format which SC understands.
 // See encode function below for more details.
 module.exports.decode = function (input) {
@@ -72,7 +78,7 @@ module.exports.decode = function (input) {
   }
 
   try {
-    return JSON.parse(message);
+    return JSON.parse(message, base64ToBinaryReplacer);
   } catch (err) {}
   return message;
 };


### PR DESCRIPTION
When encoding, we use a replacer to encode `Buffer` instance into `{ base64: true, data }` object (where data is base64).

The reverse operation was not implemented when decoding.

If you agree with this @jondubois there might be another change needed : here the replacer decodes to `Buffer` only but the encoding replacer also handles `ArrayBuffer`.
But I prefer to wait for you opinion and validation before doing more.